### PR TITLE
remover fluxo de abertura de arquivo da main

### DIFF
--- a/biblioteca.c
+++ b/biblioteca.c
@@ -298,18 +298,14 @@ int salvar(struct estadoPrograma *state){
 
 int carregar(struct estadoPrograma *ponteiroEstado){
     FILE *f = fopen("dados.bin", "rb");
-    if(f == NULL){
-        printf("ERRO:\n");
-        printf("Nao foi posivel abrir o arquivo dados.bin");
+    if(f == NULL)
         return ERRO_ARQUIVO;
-    }
     // carrega o tamanho
     fread(&(ponteiroEstado->tamanho), sizeof(int), 1, f);
     // carrega a array de contas
     for(int i = 0; i < ponteiroEstado->tamanho; i++){
         fread(&(ponteiroEstado->memoria[i]), sizeof(struct conta), 1, f);
     }
-    printf("Contas carregadas com sucesso!\n");
     fclose(f);
     return SUCESSO;
 }

--- a/main.c
+++ b/main.c
@@ -2,20 +2,11 @@
 #include "biblioteca.h"
 int main() {
     struct estadoPrograma state;
-    FILE *f;
-    f = fopen("dados.bin", "rb");
-    if(f){
-        carregar(&state); //carrega os dados do estado do programa (array de tarefas, tamanho)
-        fclose(f);
-    }
-    else{
-        fclose(f);
-        f = fopen("dados.bin", "wb");
-        int t = 0;
-        fwrite(&t, sizeof(int), 1, f);
-        fclose(f);
-        state.tamanho = t;
-        printf("Arquivo nao encontrado!\ndados.bin foi criado com sucesso.\n");
+    if(carregar(&state) == SUCESSO){
+        printf("Arquivo carregado com sucesso.\n");
+    }else{
+        printf("Arquivo nao encontrado.\n");
+        printf("Criando novo arquivo.\n");
     }
     state.estadoLoop = FUNCIONANDO;
     do{


### PR DESCRIPTION
Haviam 2 blocos de código que performavam a mesma função de abertura/checagem dos arquivos para a persistência: um na main, e uma função carregar(). A que estava presente na main impossibilitava o programa de rodar caso nenhum arquivo binário fosse encontrado no diretório. Isso acontecia por que o ponteiro do arquivo era assinalado com a função fopen() no modo de leitura binária, que retorna um ponteiro NULL caso não seja possível localizar o arquivo. A partir disso, era utilizado a função fclose() para fechar esse ponteiro NULL, o que causava o erro Segmentation Fault em alguns ambientes. Agora, essa funcionalidade é delegada para a função carregar() importada da biblioteca, que funcionava corretamente com um early return em caso de ausência do arquivo. Adicionalmente, o error handling dessa função agora é feito diretamente na main em vez da função, a fim de manter o padrão do código.